### PR TITLE
JAVA-6166 Add github workflows

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -1,0 +1,23 @@
+name: publish snapshot on main merge
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 8
+      - name: Build with Gradle
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew build publishMavenJavaPublicationToMavenRepository

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,24 @@
+name: publish release version explicitly
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 8
+      - name: Build with Gradle
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew build publishMavenJavaPublicationToMavenRepository -Prelease=true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,17 @@
+name: Java PR build (gradle)
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 8
+      - name: Build with Gradle
+        run: ./gradlew build


### PR DESCRIPTION
```
 $ act pull_request
[Java PR build (gradle)/build] 🚀  Start image=node:12.6-buster-slim
[Java PR build (gradle)/build]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Java PR build (gradle)/build]   🐳  docker cp src=/Users/jkeller/code/newrelic-gradle-compatibility-doc-plugin/. dst=/github/workspace
[Java PR build (gradle)/build] ⭐  Run actions/checkout@v2
[Java PR build (gradle)/build]   ✅  Success - actions/checkout@v2
[Java PR build (gradle)/build] ⭐  Run Set up JDK 1.8
[Java PR build (gradle)/build]   ☁  git clone 'https://github.com/actions/setup-java' # ref=v1.3.0
[Java PR build (gradle)/build]   🐳  docker cp src=/Users/jkeller/.cache/act/actions-setup-java@v1.3.0 dst=/actions/
[Java PR build (gradle)/build]   💬  ##[debug]isExplicit:
[Java PR build (gradle)/build]   💬  ##[debug]explicit? false
[Java PR build (gradle)/build]   💬  ##[debug]evaluating 0 versions
[Java PR build (gradle)/build]   💬  ##[debug]match not found
[Java PR build (gradle)/build]   💬  ##[debug]Downloading Jdk from Azul
[Java PR build (gradle)/build]   💬  ##[debug]Downloading https://static.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-linux_x64.tar.gz
[Java PR build (gradle)/build]   💬  ##[debug]Downloading /tmp/1843ac50-d7e7-4d30-8edc-041fd85ece32
[Java PR build (gradle)/build]   💬  ##[debug]download complete
| [command]/bin/tar xzC /tmp/temp_1024475573 -f /tmp/1843ac50-d7e7-4d30-8edc-041fd85ece32
[Java PR build (gradle)/build]   💬  ##[debug]jdk extracted to /tmp/temp_1024475573/zulu8.46.0.19-ca-jdk8.0.252-linux_x64
[Java PR build (gradle)/build]   💬  ##[debug]Caching tool jdk 8.0.252 x64
[Java PR build (gradle)/build]   💬  ##[debug]source dir: /tmp/temp_1024475573/zulu8.46.0.19-ca-jdk8.0.252-linux_x64
[Java PR build (gradle)/build]   💬  ##[debug]destination /opt/hostedtoolcache/jdk/8.0.252/x64
[Java PR build (gradle)/build]   💬  ##[debug]finished caching tool
[Java PR build (gradle)/build]   ⚙  ::set-env:: JAVA_HOME=/opt/hostedtoolcache/jdk/8.0.252/x64
[Java PR build (gradle)/build]   ⚙  ::set-env:: JAVA_HOME_8.0.252_x64=/opt/hostedtoolcache/jdk/8.0.252/x64
[Java PR build (gradle)/build]   ⚙  ::add-path:: /opt/hostedtoolcache/jdk/8.0.252/x64/bin
[Java PR build (gradle)/build]   ❓  ##[add-matcher]/actions/actions-setup-java@v1.3.0/.github/java.json
| creating settings.xml with server-id: github; environment variables: username=$GITHUB_ACTOR and password=$GITHUB_TOKEN
[Java PR build (gradle)/build]   💬  ##[debug]created directory /github/home/.m2
| writing /github/home/.m2/settings.xml
[Java PR build (gradle)/build]   ✅  Success - Set up JDK 1.8
[Java PR build (gradle)/build] ⭐  Run Build with Gradle
| Downloading https://services.gradle.org/distributions/gradle-5.6.2-all.zip
| .....................................................................................................................................
| Unzipping /root/.gradle/wrapper/dists/gradle-5.6.2-all/9st6wgf78h16so49nn74lgtbb/gradle-5.6.2-all.zip to /root/.gradle/wrapper/dists/gradle-5.6.2-all/9st6wgf78h16so49nn74lgtbb
| Set executable permissions for: /root/.gradle/wrapper/dists/gradle-5.6.2-all/9st6wgf78h16so49nn74lgtbb/gradle-5.6.2/bin/gradle
|
| Welcome to Gradle 5.6.2!
|
| Here are the highlights of this release:
|  - Incremental Groovy compilation
|  - Groovy compile avoidance
|  - Test fixtures for Java projects
|  - Manage plugin versions via settings script
|
| For more details see https://docs.gradle.org/5.6.2/release-notes.html
|
| Starting a Gradle Daemon (subsequent builds will be faster)
|
| > Configure project :
| no credentials present for newrelic-maven-publish, `publish` and `uploadArchives` may fail
|
| > Task :compileJava
| Note: /github/workspace/src/main/java/com/newrelic/agent/instrumentation/compatibility/CompatibilitySiteTask.java uses or overrides a deprecated API.
| Note: Recompile with -Xlint:deprecation for details.
| Note: Some input files use unchecked or unsafe operations.
| Note: Recompile with -Xlint:unchecked for details.
|
| > Task :compileGroovy
| > Task :processResources
| > Task :classes
| > Task :jar
| > Task :javadocJar
| > Task :sourcesJar
| > Task :assemble
| > Task :compileTestJava NO-SOURCE
| > Task :compileTestGroovy NO-SOURCE
| > Task :processTestResources NO-SOURCE
| > Task :testClasses UP-TO-DATE
| > Task :test NO-SOURCE
| > Task :check UP-TO-DATE
| > Task :build
|
| BUILD SUCCESSFUL in 1m 27s
| 6 actionable tasks: 6 executed
[Java PR build (gradle)/build]   ✅  Success - Build with Gradle
```

```
 $ act -n
*DRYRUN* [publish snapshot on main merge/build] 🚀  Start image=node:12.6-buster-slim
*DRYRUN* [publish snapshot on main merge/build]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
*DRYRUN* [publish snapshot on main merge/build] ⭐  Run actions/checkout@v2
*DRYRUN* [publish snapshot on main merge/build]   ✅  Success - actions/checkout@v2
*DRYRUN* [publish snapshot on main merge/build] ⭐  Run Set up JDK 8
*DRYRUN* [publish snapshot on main merge/build]   ☁  git clone 'https://github.com/actions/setup-java' # ref=v1.3.0
*DRYRUN* [publish snapshot on main merge/build]   ✅  Success - Set up JDK 8
*DRYRUN* [publish snapshot on main merge/build] ⭐  Run Build with Gradle
*DRYRUN* [publish snapshot on main merge/build]   ✅  Success - Build with Gradle
```